### PR TITLE
SHA-256 optimizations and bugfixes

### DIFF
--- a/src/tls/core/sha256.asm
+++ b/src/tls/core/sha256.asm
@@ -244,8 +244,8 @@ _tls_sha256_update:
 	pop ix
 	restore_interrupts _tls_sha256_update
 	ret
- 
- _sha256_update_loop:
+
+_sha256_update_loop:
 	inc a
 	ldi ;ld (de),(hl) / inc de / inc hl / dec bc
 	ret po ;return if bc==0 (ldi decrements bc and updates parity flag)
@@ -259,10 +259,9 @@ _sha256_update_apply_transform:
 	call _sha256_transform	  ; if we have one block (64-bytes), transform block
 	pop iy
 	ld bc, 512				  ; add 1 blocksize of bitlen to the bitlen field
-	push bc
-	pea iy + sha256_offset_bitlen
+	lea iy, iy + sha256_offset_bitlen
 	call u64_addi
-	pop bc, bc, bc, de, hl
+	pop bc, de, hl
 	xor a,a
 	ld de, (ix + 6)
 	ret
@@ -319,10 +318,8 @@ _sha256_final_done_pad:
 	ld c, (iy + sha256_offset_datalen)
 	ld b,8
 	mlt bc ;multiply 8-bit datalen by 8-bit value 8
-	push bc
-	pea iy + sha256_offset_bitlen
+	lea iy, iy + sha256_offset_bitlen
 	call u64_addi
-	pop bc,bc
 	lea iy, ix-_sha256ctx_size ;ctx
 	lea hl,iy + sha256_offset_bitlen
 	lea de,iy + sha256_offset_data + 63

--- a/src/tls/core/share/bigint.asm
+++ b/src/tls/core/share/bigint.asm
@@ -3,29 +3,26 @@ assume adl=1
 
 section .text
 public u64_addi
-; void u64_addi(uint64_t *a, uint64_t *b);
+; add unsigned 24-bit BC to the 64-bit integer pointed to by IY
+; destroys AF, DE, HL
 u64_addi:
-	pop bc,hl,de
-	push de,hl,bc
 	xor a,a
-	ld bc,(hl)
-	ex hl,de
-	adc hl,bc
-	ex hl,de
-	ld (hl),de
-	inc hl
-	inc hl
-	inc hl
-	ld b,5
-	ld c,a
-.loop:
-	ld a,(hl)
-	adc a,c
+	sbc hl,hl
+	ex de,hl
+	ld hl,(iy)
+	add hl,bc
+	ld (iy),hl
+	ld hl,(iy+3)
+	adc hl,de
+	ld (iy+3),hl
+	lea hl,iy+6
+	adc a,(hl)
 	ld (hl),a
 	inc hl
-	djnz .loop
+	ld a,(hl)
+	adc a,e
+	ld (hl),a
 	ret
-
 
 section .text
 public _gf128_mul


### PR DESCRIPTION
Improves SHA-256 calculation speed by approximately 2.5 times, and reduces the library size by 255 bytes.

Changes u64_addi to use register parameters since it's not exposed to C code.

Fixes a bug in tls_sha256_update where a zero-length input is not handled correctly.

Fixes a bug in tls_sha256_digest where the digest of a message of length at least 56 bytes mod 64 is not calculated correctly.